### PR TITLE
SANTUARIO-553 - Move logging of provider below init.

### DIFF
--- a/src/main/java/org/apache/xml/security/signature/XMLSignature.java
+++ b/src/main/java/org/apache/xml/security/signature/XMLSignature.java
@@ -857,7 +857,6 @@ public final class XMLSignature extends SignatureElementProxy {
             SignatureAlgorithm sa = si.getSignatureAlgorithm();
             LOG.debug("signatureMethodURI = {}", sa.getAlgorithmURI());
             LOG.debug("jceSigAlgorithm = {}", sa.getJCEAlgorithmString());
-            LOG.debug("jceSigProvider = {}", sa.getJCEProviderName());
             LOG.debug("PublicKey = {}", pk);
 
             byte[] sigBytes = null;
@@ -865,6 +864,7 @@ public final class XMLSignature extends SignatureElementProxy {
                 OutputStream bos = new UnsyncBufferedOutputStream(so)) {
 
                 sa.initVerify(pk);
+                LOG.debug("jceSigProvider = {}", sa.getJCEProviderName());
 
                 // Get the canonicalized (normalized) SignedInfo
                 si.signInOctetStream(bos);


### PR DESCRIPTION
Allows init to select the provider based on algorithm and key, not just algorithm.